### PR TITLE
make button list expand for controllers with more than 16 buttons

### DIFF
--- a/index.js
+++ b/index.js
@@ -541,8 +541,17 @@ function createGamepadAgent() {
         let buttonStates = 0; // Single integer to hold all 16 button states
     
         if (gamepad) {
-            const buttonCount = Math.min(gamepad.buttons.length, 16); // Limit to 16 buttons
-    
+            let buttonCount = gamepad.buttons.length;
+            // expand the button array if the gamepad has more than 16 buttons
+            while(buttonCount > buttonElements.length - 1){
+                buttonContainerDiv=document.getElementById('desktop-button');
+                newButton = document.createElement('button');
+                newButton.id = "buttonDesktop" + buttonElements.length;
+                newButton.innerHTML = buttonElements.length;
+                buttonContainerDiv.appendChild(newButton);
+                buttonElements = document.querySelectorAll('[id^="buttonDesktop"]');
+            }
+
             for (let i = 0; i < buttonCount; i++) {
                 const button = gamepad.buttons[i];
                 if (button && button.pressed) {

--- a/index.js
+++ b/index.js
@@ -543,7 +543,7 @@ function createGamepadAgent() {
         if (gamepad) {
             let buttonCount = gamepad.buttons.length;
             // expand the button array if the gamepad has more than 16 buttons
-            while(buttonCount > buttonElements.length - 1){
+            while(buttonElements.length < buttonCount){
                 buttonContainerDiv=document.getElementById('desktop-button');
                 newButton = document.createElement('button');
                 newButton.id = "buttonDesktop" + buttonElements.length;


### PR DESCRIPTION
This is in response to Braeden's question about "Pesto link doesn't see a button on my controller that Alfredo Connect does."

you can test it with this link https://joshua-8.github.io/PestoLink-Online/

I tested with a Raspberry Pi Pico programmed to act like a joystick with 32 buttons https://github.com/benjaminaigner/Joystick/blob/main/examples/Joystick-AllFunctions/Joystick-AllFunctions.ino

When I connect an XBox controller, a 17th button appears (button number 16 since they start at zero). This site (https://hardwaretester.com/gamepad) also shows my XBox controller as having 17 buttons.